### PR TITLE
Converted concatenated strings to template literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ ResultStore.prototype.private_collate = function (result, name) {
         if (!result[key]) continue;
         if (!result[key].length) continue;
         if (hide && hide.length && hide.indexOf(key) !== -1) continue;
-        r.push( `${key}: ${result[key].join(', ')}`);
+        r.push( `${key}:${result[key].join(', ')}`);
     }
 
     return r;

--- a/index.js
+++ b/index.js
@@ -61,10 +61,7 @@ ResultStore.prototype.redis_publish = function (name, obj) {
     if (!this.conn.server || !this.conn.server.notes) return;
     if (!this.conn.server.notes.redis) return;
 
-    const channel = 'result-' +
-        (this.conn.transaction ?
-            this.conn.transaction.uuid :
-            this.conn.uuid);
+    const channel = `result-${this.conn.transaction ? this.conn.transaction.uuid : this.conn.uuid}`;
 
     this.conn.server.notes.redis.publish(channel,
         JSON.stringify({ plugin: name, result: obj }));
@@ -197,7 +194,7 @@ ResultStore.prototype.private_collate = function (result, name) {
                 continue;
             }
         }
-        r.push(key + ': ' + result[key]);
+        r.push(`${key}: ${result[key]}`);
     }
 
     // and then supporting information
@@ -210,7 +207,7 @@ ResultStore.prototype.private_collate = function (result, name) {
         if (!result[key]) continue;
         if (!result[key].length) continue;
         if (hide && hide.length && hide.indexOf(key) !== -1) continue;
-        r.push( key + ':' + result[key].join(', '));
+        r.push( `${key}: ${result[key].join(', ')}`);
     }
 
     return r;

--- a/test/result_store.js
+++ b/test/result_store.js
@@ -214,7 +214,7 @@ exports.redis_publish = {
             test.done();
         })
             .on('psubscribe', function (pattern, count) {
-            // console.log('psubscribed to ' + pattern);
+            // console.log(`psubscribed to ${pattern}`);
                 conn.results.add({ name: 'pi'}, { pass: 'the test'});
             })
             .psubscribe('*');


### PR DESCRIPTION
Fixes # Replace string concatenations with template literals

Changes proposed in this pull request:
- 
- 

Checklist:
- [ ] docs updated
- [X ] tests updated
- [ ] Changes.md updated
- [ ] package.json.version bumped
- [ ] published to NPM (will be done by @core)